### PR TITLE
BindablEnum.FluentValidation

### DIFF
--- a/BindableEnum.FluentValidation/Library/BindableEnum.FluentValidation.Library.csproj
+++ b/BindableEnum.FluentValidation/Library/BindableEnum.FluentValidation.Library.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Version>1.0.0</Version>
+    <Description>Extensions for the FluentValidations library within the context of the BindableEnum library.</Description>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPkgVer)" PrivateAssets="All" />
+    <PackageReference Include="Woody230.BindableEnum" Version="1.3.0" />
+    <PackageReference Include="Woody230.FluentValidation" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/BindableEnum.FluentValidation/Library/README.md
+++ b/BindableEnum.FluentValidation/Library/README.md
@@ -1,0 +1,6 @@
+![](https://img.shields.io/github/license/Woody230/CSharpExtensions)
+[![](https://img.shields.io/nuget/v/Woody230.BindableEnum.FluentValidation)](https://www.nuget.org/packages/Woody230.BindableEnum.FluentValidation)
+
+# BindableEnum.FluentValidation
+
+Extensions for the [FluentValidation](https://github.com/FluentValidation/FluentValidation) library within the context of the [BindableEnum](https://www.nuget.org/packages/Woody230.BindableEnum) library.

--- a/BindableEnum.FluentValidation/Library/README.md
+++ b/BindableEnum.FluentValidation/Library/README.md
@@ -4,3 +4,10 @@
 # BindableEnum.FluentValidation
 
 Extensions for the [FluentValidation](https://github.com/FluentValidation/FluentValidation) library within the context of the [BindableEnum](https://www.nuget.org/packages/Woody230.BindableEnum) library.
+
+# Validators
+
+## Property Validators
+| Name | Description | 
+| --- | --- |
+| BindableEnumPropertyValidator | Validates that the enum has binded. Extends from the OptionalPropertyValidator so nulls are automatically valid. |

--- a/BindableEnum.FluentValidation/Library/Validators/Property/BindableEnumPropertyValidator.cs
+++ b/BindableEnum.FluentValidation/Library/Validators/Property/BindableEnumPropertyValidator.cs
@@ -1,0 +1,43 @@
+﻿using FluentValidation;
+using System;
+using System.Linq;
+using Woody230.BindableEnum.Models;
+using Woody230.FluentValidation.Resources;
+using Woody230.FluentValidation.Validators.Property;
+
+namespace Woody230.BindableEnum.FluentValidation.Validators.Property;
+
+/// <summary>
+/// Validates that a bindable enum has been successfully binded.
+/// </summary>
+/// <typeparam name="T">The type of model.</typeparam>
+public sealed class BindableEnumPropertyValidator<T, TProperty> : OptionalPropertyValidator<T, TProperty> where TProperty : IBindableEnum
+{
+    public const string EnumName = "EnumName";
+    public const string EnumValues = "EnumValues";
+
+    protected override ErrorMessageTemplateBuilder BuildDefaultErrorMessage(string errorCode)
+    {
+        return new ErrorMessageTemplateBuilder()
+            .Append("value `")
+            .AppendPropertyValue()
+            .Append("` must be one of the following ")
+            .AppendPlaceholder(EnumName)
+            .Append(" values: ")
+            .AppendPlaceholder(EnumValues);
+    }
+
+    protected override bool IsPropertyValid(ValidationContext<T> context, TProperty value)
+    {
+        if (value.Binded)
+        {
+            return true;
+        }
+
+        var valueType = value.GetType();
+        var enumName = valueType.IsGenericType ? valueType.GetGenericArguments()[0].Name : string.Empty;
+        var expectedValues = value.Enum.GetType().GetEnumValues().Cast<Enum>().Select(@enum => @enum.ToString());
+        context.MessageFormatter.AppendArgument(EnumName, enumName).AppendArgument(EnumValues, string.Join(", ", expectedValues));
+        return false;
+    }
+}

--- a/BindableEnum.FluentValidation/Library/Validators/Property/RuleBuilderExtensions.cs
+++ b/BindableEnum.FluentValidation/Library/Validators/Property/RuleBuilderExtensions.cs
@@ -1,0 +1,23 @@
+﻿using FluentValidation;
+using Woody230.BindableEnum.Models;
+
+namespace Woody230.BindableEnum.FluentValidation.Validators.Property;
+
+/// <summary>
+/// Represents extensions for the <see cref="IRuleBuilder{T, TProperty}"/>.
+/// </summary>
+public static class RuleBuilderExtensions
+{
+    /// <summary>
+    /// Applies the <see cref="BindableEnumPropertyValidator{T, TProperty}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of model.</typeparam>
+    /// <typeparam name="TProperty">The type of property.</typeparam>
+    /// <param name="ruleBuilder">The rule builder.</param>
+    /// <returns>The rule builder options.</returns>
+    public static IRuleBuilderOptions<T, TProperty> BindedEnum<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder) where TProperty: IBindableEnum
+    {
+        var validator = new BindableEnumPropertyValidator<T, TProperty>();
+        return ruleBuilder.SetValidator(validator);
+    }
+}

--- a/BindableEnum.FluentValidation/Tests/BindableEnum.FluentValidation.Tests.csproj
+++ b/BindableEnum.FluentValidation/Tests/BindableEnum.FluentValidation.Tests.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkPkgVer)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Internal\Tests\Internal.Tests.csproj" />
+    <ProjectReference Include="..\Library\BindableEnum.FluentValidation.Library.csproj" />
+  </ItemGroup>
+</Project>

--- a/BindableEnum.FluentValidation/Tests/Validator/Property/BindableEnumPropertyValidatorTests.cs
+++ b/BindableEnum.FluentValidation/Tests/Validator/Property/BindableEnumPropertyValidatorTests.cs
@@ -12,7 +12,7 @@ namespace Woody230.BindableEnum.FluentValidation.Tests.Validator.Property;
 public class BindableEnumPropertyValidatorTests
 {
     [Theory]
-    [InlineData(null, true)]
+    [InlineData(null, false, "'Enum' value `` must be one of the following Color values: Red, Blue")]
     [InlineData("", false, "'Enum' value `` must be one of the following Color values: Red, Blue")]
     [InlineData("Red", true)]
     [InlineData("Blue", true)]
@@ -21,7 +21,7 @@ public class BindableEnumPropertyValidatorTests
     {
         // Arrange
         var validator = new WrapperValidator();
-        var wrapper = new Wrapper() { Enum = @enum == null ? null : new BindableEnum<Color>(@enum) };
+        var wrapper = new Wrapper() { Enum = new BindableEnum<Color>(@enum) };
 
         // Act
         var result = validator.Validate(wrapper);
@@ -40,6 +40,20 @@ public class BindableEnumPropertyValidatorTests
             error.PropertyName.Should().Be("Enum");
             error.ErrorMessage.Should().Be(message);
         }
+    }
+
+    [Fact]
+    public void Null_BindableEnum_IsValid()
+    {
+        // Arrange
+        var validator = new WrapperValidator();
+        var wrapper = new Wrapper();
+
+        // Act
+        var result = validator.Validate(wrapper);
+
+        // Assert
+        result.IsValid.Should().Be(true);
     }
 
     private record Wrapper

--- a/BindableEnum.FluentValidation/Tests/Validator/Property/BindableEnumPropertyValidatorTests.cs
+++ b/BindableEnum.FluentValidation/Tests/Validator/Property/BindableEnumPropertyValidatorTests.cs
@@ -1,0 +1,63 @@
+﻿using FluentAssertions;
+using FluentValidation;
+using Woody230.BindableEnum.FluentValidation.Validators.Property;
+using Woody230.BindableEnum.Models;
+using Xunit;
+
+namespace Woody230.BindableEnum.FluentValidation.Tests.Validator.Property;
+
+/// <summary>
+/// Represents tests for the <see cref="BindableEnumPropertyValidator{T, TProperty}"/>
+/// </summary>
+public class BindableEnumPropertyValidatorTests
+{
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("", false, "'Enum' value `` must be one of the following Color values: Red, Blue")]
+    [InlineData("Red", true)]
+    [InlineData("Blue", true)]
+    [InlineData("Green", false, "'Enum' value `Green` must be one of the following Color values: Red, Blue")]
+    public void BindedEnum_IsValid(string @enum, bool expected, string message = null)
+    {
+        // Arrange
+        var validator = new WrapperValidator();
+        var wrapper = new Wrapper() { Enum = @enum == null ? null : new BindableEnum<Color>(@enum) };
+
+        // Act
+        var result = validator.Validate(wrapper);
+
+        // Assert
+        result.IsValid.Should().Be(expected);
+        
+        if (expected)
+        {
+            result.Errors.Should().BeEmpty();
+        }
+        else
+        {
+            result.Errors.Should().HaveCount(1);
+            var error = result.Errors[0];
+            error.PropertyName.Should().Be("Enum");
+            error.ErrorMessage.Should().Be(message);
+        }
+    }
+
+    private record Wrapper
+    {
+        public BindableEnum<Color> Enum { get; init; }
+    }
+
+    private enum Color
+    {
+        Red,
+        Blue,
+    }
+
+    private class WrapperValidator: AbstractValidator<Wrapper>
+    {
+        public WrapperValidator() 
+        {
+            RuleFor(wrapper => wrapper.Enum).BindedEnum();
+        }
+    }
+}

--- a/CSharpExtensions.sln
+++ b/CSharpExtensions.sln
@@ -37,7 +37,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Text", "Text", "{51633B31-F
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Text.Library", "Text\Library\Text.Library.csproj", "{29906E7B-4CE3-41B1-AE23-94F33C296104}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Text.Tests", "Text\Tests\Text.Tests.csproj", "{DF290BB8-1AA6-46D5-AA6F-D1DFF62F33C8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Text.Tests", "Text\Tests\Text.Tests.csproj", "{DF290BB8-1AA6-46D5-AA6F-D1DFF62F33C8}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "BindableEnum.FluentValidation", "BindableEnum.FluentValidation", "{BBABA672-E3F8-4DD3-8C20-07E1977652D0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BindableEnum.FluentValidation.Library", "BindableEnum.FluentValidation\Library\BindableEnum.FluentValidation.Library.csproj", "{9CE6B0F9-9267-47F3-A941-F808B1000FAA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BindableEnum.FluentValidation.Tests", "BindableEnum.FluentValidation\Tests\BindableEnum.FluentValidation.Tests.csproj", "{9540FEB9-CD75-4471-AA64-0374246E6C6B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -85,6 +91,14 @@ Global
 		{DF290BB8-1AA6-46D5-AA6F-D1DFF62F33C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF290BB8-1AA6-46D5-AA6F-D1DFF62F33C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF290BB8-1AA6-46D5-AA6F-D1DFF62F33C8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9CE6B0F9-9267-47F3-A941-F808B1000FAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9CE6B0F9-9267-47F3-A941-F808B1000FAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9CE6B0F9-9267-47F3-A941-F808B1000FAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9CE6B0F9-9267-47F3-A941-F808B1000FAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9540FEB9-CD75-4471-AA64-0374246E6C6B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9540FEB9-CD75-4471-AA64-0374246E6C6B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9540FEB9-CD75-4471-AA64-0374246E6C6B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9540FEB9-CD75-4471-AA64-0374246E6C6B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -100,6 +114,8 @@ Global
 		{DCC33301-B030-490E-9D9B-F315C3F8C72E} = {9D53864C-34A2-450A-A294-355907E774DF}
 		{29906E7B-4CE3-41B1-AE23-94F33C296104} = {51633B31-F408-4DE1-9157-D64CB96507A6}
 		{DF290BB8-1AA6-46D5-AA6F-D1DFF62F33C8} = {51633B31-F408-4DE1-9157-D64CB96507A6}
+		{9CE6B0F9-9267-47F3-A941-F808B1000FAA} = {BBABA672-E3F8-4DD3-8C20-07E1977652D0}
+		{9540FEB9-CD75-4471-AA64-0374246E6C6B} = {BBABA672-E3F8-4DD3-8C20-07E1977652D0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B59A3CED-A160-49B9-A001-B4EA679E9D25}

--- a/FluentValidation/Library/FluentValidation.Library.csproj
+++ b/FluentValidation/Library/FluentValidation.Library.csproj
@@ -6,8 +6,6 @@
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="$(FluentValidationPkgVer)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="$(MicrosoftSourceLinkGitHubPkgVer)" PrivateAssets="All" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\Text\Library\Text.Library.csproj" />
+    <PackageReference Include="Woody230.Text" Version="1.0.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 | Name | NuGet | Description |
 | --- | --- | --- | 
-| [BindableEnum](BindableEnum\Library\README.md) | [![](https://img.shields.io/nuget/v/Woody230.BindableEnum)](https://www.nuget.org/packages/Woody230.BindableEnum) | Enumeration wrapper for manual model state validation in ASP.NET Core. |
-| [FluentValidation](FluentValidation\Library\README.md) | [![](https://img.shields.io/nuget/v/Woody230.FluentValidation)](https://www.nuget.org/packages/Woody230.FluentValidation) | Extensions for the [FluentValidation](https://github.com/FluentValidation/FluentValidation) library. |
-| [Text](Text\Library\README.md) | [![](https://img.shields.io/nuget/v/Woody230.Text)](https://www.nuget.org/packages/Woody230.Text) | Extensions for the System.Text namespace. |
+| [BindableEnum](BindableEnum\\Library\\README.md) | [![](https://img.shields.io/nuget/v/Woody230.BindableEnum)](https://www.nuget.org/packages/Woody230.BindableEnum) | Enumeration wrapper for manual model state validation in ASP.NET Core. |
+| [BindableEnum.FluentValidation](BindableEnum.FluentValidation\\Library\\README.md) | [![](https://img.shields.io/nuget/v/Woody230.BindableEnum.FluentValidation)](https://www.nuget.org/packages/Woody230.BindableEnum.FluentValidation) | Extensions for the [FluentValidation](https://github.com/FluentValidation/FluentValidation) library within the context of the [BindableEnum](BindableEnum\\Library\\README.md) library. |
+| [FluentValidation](FluentValidation\\Library\\README.md) | [![](https://img.shields.io/nuget/v/Woody230.FluentValidation)](https://www.nuget.org/packages/Woody230.FluentValidation) | Extensions for the [FluentValidation](https://github.com/FluentValidation/FluentValidation) library. |
+| [Text](Text\\Library\\README.md) | [![](https://img.shields.io/nuget/v/Woody230.Text)](https://www.nuget.org/packages/Woody230.Text) | Extensions for the System.Text namespace. |


### PR DESCRIPTION
# BindableEnum.FluentValidation

Extensions for the [FluentValidation](https://github.com/FluentValidation/FluentValidation) library within the context of the [BindableEnum](https://www.nuget.org/packages/Woody230.BindableEnum) library.

# Validators

## Property Validators
| Name | Description | 
| --- | --- |
| BindableEnumPropertyValidator | Validates that the enum has binded. Extends from the OptionalPropertyValidator so nulls are automatically valid. |
